### PR TITLE
do not minify files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build static site contents
         run: |
-          node build.js -f -m
+          node build.js -f
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/build.js
+++ b/build.js
@@ -44,7 +44,7 @@ ${[...modules].map(x => `    ${x}`).join('\n')}
 Options:
     --help | -h      Display usage help.
     --force | -f     Skip update check and rebuild all requested parts.
-    --minify | -m    Minify HTML/CSS/JS files.
+    --minify | -m    Minify HTML/CSS/JS files. [experimental]
 `;
 	process.stdout.write(usage);
 	process.exit(0);


### PR DESCRIPTION
我找了幾個最大的檔案測試壓縮和 minify 效果。根據版本 197967123baa2e9e757ccf2456e71734277b1169

以下表記為 `A => B; C => D`。A 表示原輸出檔大小，B 表示其 gzip 後的大小；C 表示原檔經 minify 處理的大小，D 表示其 gzip 壓縮後的大小。單位都是 KB。沒有 C => D 的表示目前程式沒有 minify。

```
combos.html: 163 => 14
unit.js  90 => 20 ; 62 => 20
stage.js 55 => 14 ; 41 => 14
schedule.html 53 => 11; 49 => 11
treasure_list.html 52 => 15; 51 => 15
rank.html 49 => 4; 49 => 4
```

以結果來看：
1. 一般而言 gzip 壓縮就非常夠用了，minify 對於改善傳輸量和傳輸時間的幫助小到可忽略
2. minify 對改善執行效能的幫助也存疑（除非真的跑 benchmark 有顯著差異，以目前程式規模來看極可能是小到可忽略）
3. minify 不利於除錯，本來跑線上版時打開瀏覽器工具就能查程式碼和設斷點，minify 後就不行，得重新在本地 checkout 同一版本，重新生成未 minify 的內容再開本地伺服器測試，麻煩得多
4. minify 腳本可能會改變邏輯，有機會造成不可預期的錯誤（我以前就遇過），增加除錯上的困擾。比如以目前專案來說，unit.js 第一行的 `const my_params = ...` 在 minify 後就變成了 `let my_params = ...`。而 HTML 的 minify 也一樣伴隨著風險，比如遇到 CSS 設定 preserve whitespaces 的元素，minify 移除空白就爆了
5. 承上，通常在本地是測試未 minify 版本，但線上釋出的是 minify 版本，這之間的差異就可能造成問題。比較專業的做法是本地測試也 minify，但附上 source map 以便除錯，但以目前程式的狀態，要這麼做也得重構，又是一番折騰。
6. minify 的參數非常多，目前的參數只是粗略挑選而已，UglifyJS 的參數甚一個都沒有，而 html-minifier 調用 UglifyJS 時使用的參數也要研究，如果和前者不一致，那還得考慮所有 js 要 inline 或是作為分開的檔案。要最大化縮小程式碼、提高效能，又最小化可能出錯的風險，所需的參數和其他配套措施需要很多測試，簡而言之就是水很深。
7. 本專案是公開原始碼，minify 沒有防止他人偷程式的效果
8. 目前程式 copy-assets.js 有做 minify，還有很多地方沒有 minify 到，要做比較好的全面處理一般來說得把 minify 參數做成 config，這大概要等如 #19 所述生成器重構完成以後才能統一傳遞參數給所有要生成的檔案。

我認為沒必要為了微不足道的效能差異增加除錯的麻煩及因邏輯變動導致出錯的風險。建議 workflow 取消 minify 並在 usage 加註為 experimental feature。目前的問題還有很多，應該優先把時間和精力放在解決其他問題，哪天真的吃飽太太太太閒的時候再考慮搞這個。