### PR TITLE
fix alignments in dropdowns

### DIFF
--- a/template/html/anim.html
+++ b/template/html/anim.html
@@ -51,6 +51,7 @@ input, select { font-size: max(2vh, 12px);outline:none; }
 	float: right;
 }
 .dropdown p {
+	display: inline-block;
 	vertical-align: middle;
 	padding-right: 0.5vw;
 	width: min(40vw, 200px);


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/a15b9f93-294a-4ce8-a74e-9eb45d05ea65)
after
![image](https://github.com/user-attachments/assets/95f0452d-4f0a-4ab0-b59d-134b9fa4ed5a)
因為要選單文字跟他的子元素在不同解析度的螢幕上都垂直置中實在太麻煩了，所以我就讓他不要凸出去就好。
然後這是用4K、顯示比例150%截出來的，用1080P螢幕好像完幾乎沒差，我的手機顯示也原本就是好的。