### PR TITLE
fix metal_killer.js NaN hp value

### DIFF
--- a/template/js/metal_killer.js
+++ b/template/js/metal_killer.js
@@ -14,7 +14,7 @@ let chart;
 })();
 
 (S.onclick = HP.oninput = kill.oninput = function () {
-	let hp = Math.max(parseInt(HP.value), 1);
+	let hp = Math.max(parseInt(HP.value) || 1, 1);
 	let Ys = [{y: hp}];
 	let m = parseInt(kill.value) / 100;
 	while (true) {


### PR DESCRIPTION
Fix metal_killer crash bug when hp input is empty. This will cause the whole web browser freeze then crash.