### PR TITLE
Fix: Make name search case-insensitive

### DIFF
--- a/template/js/esearch.js
+++ b/template/js/esearch.js
@@ -37,13 +37,13 @@ document.getElementById('per_page').oninput = function setRange(e) {
 };
 
 function filterByNameOrId(results) {
-	const key = name_search.value.trim();
+	const key = name_search.value.toLowerCase().trim();
 	if (!key)
 		return results;
 	const qid = /^\d+$/.test(key) ? parseInt(key, 10) : null;
 	return results.filter(result => {
 		const f = result[1];
-		return (f.id === qid) || f.name.includes(key) || f.jp_name.includes(key);
+		return (f.id === qid) || f.name.toLowerCase().includes(key) || f.jp_name.toLowerCase().includes(key);
 	});
 }
 

--- a/template/js/search.js
+++ b/template/js/search.js
@@ -57,7 +57,7 @@ document.getElementById('per_page').oninput = function setRange(e) {
 };
 
 function filterByNameOrId(results) {
-	const key = name_search.value.trim();
+	const key = name_search.value.toLowerCase().trim();
 	if (!key)
 		return results;
 	const qid = /^\d+$/.test(key) ? parseInt(key, 10) : null;
@@ -65,7 +65,7 @@ function filterByNameOrId(results) {
 	if (form_s === 0) {
 		return results.filter(result => {
 			const f = result[1];
-			return (f.id === qid) || f.name.includes(key) || f.jp_name.includes(key);
+			return (f.id === qid) || f.name.toLowerCase().includes(key) || f.jp_name.toLowerCase().includes(key);
 		});
 	}
 
@@ -73,7 +73,7 @@ function filterByNameOrId(results) {
 	for (const cat of cats) {
 		if (!(
 			cat.id === qid ||
-			cat.forms.some(f => f.name.includes(key) || f.jp_name.includes(key))
+			cat.forms.some(f => f.name.toLowerCase().includes(key) || f.jp_name.toLowerCase().includes(key))
 		)) {
 			cats.delete(cat);
 		}


### PR DESCRIPTION
### Problem
搜尋saber的時候因為開頭s沒有大寫便搜尋不到，能大小寫相容會較容易查詢，否則saber這種全英文名字的只要大小寫錯誤就會搜尋不到了

### Solution
- 在对比名字的function里面增加 `.toLowerCase()` 来确保大小写能够成功对比
- `search.js` (cats) 和 `esearch.js`

### Changes
- `template/js/search.js`: 更改 `filterByNameOrId()` function
- `template/js/esearch.js`: 更改 `filterByNameOrId()` function

### Testing
- 搜索 "saber" 可以搜索到 "Saber Alter CC" 和 "貓Saber Alter"
- 搜索 "SABER" 可若搜索到 "Saber Alter CC" 和 "貓Saber Alter"
- 日文搜寻还是可以使用
- 没打任何搜寻名称会显示所有猫咪