### PR TITLE
add enemy stage search page (月任務)

### DIFF
--- a/js/assets.js
+++ b/js/assets.js
@@ -34,6 +34,7 @@ const sources = [
 	'rank.html',
 	'translator.html',
 	'stage_difficulty.html',
+	'enemy_stage_search.html',
 
 	'uni.png',
 	'favicon.ico',
@@ -79,6 +80,7 @@ const sources = [
 	'gif.worker.min.js',
 	'imgcut.js',
 	'stage.js',
+	'enemy_stage_search.js',
 	'anim.min.js',
 	'imgcut.js'
 ];

--- a/template/html/enemy_stage_search.html
+++ b/template/html/enemy_stage_search.html
@@ -86,6 +86,9 @@
 #status { margin: 8px 0; font-size: 0.95em; color: #555; }
 	:root.dark #status { color: #aaa; }
 	#results table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+	.sortable { cursor: pointer; user-select: none; }
+	.sortable:hover { background: #bbb8a34d; }
+	:root.dark .sortable:hover { background: #9191914d; }
 	#results td { border: 1px solid #575757; padding: 6px 8px; vertical-align: middle; }
 	#results thead td { background: #9d9a834d; font-weight: bold; }
 	:root.dark #results thead td { background: #7171714d; }
@@ -127,7 +130,7 @@
 					<td id="col-map" hidden>地圖</td>
 					<td>關卡</td>
 					<td>包含的指定敵人</td>
-					<td>消費統率力</td>
+					<td id="col-energy">消費統率力</td>
 				</tr>
 			</thead>
 			<tbody id="results-body"></tbody>

--- a/template/html/enemy_stage_search.html
+++ b/template/html/enemy_stage_search.html
@@ -1,0 +1,152 @@
+{{#> common.html nav_bar_active="enemy_stage_search"}}
+
+{{#*inline "title"}}敵人關卡查詢{{/inline}}
+
+{{#*inline "description"}}查詢章節中包含指定敵人的關卡{{/inline}}
+
+{{#*inline "og"}}
+	{{~> @partial-block}}
+{{/inline}}
+
+{{#*inline "scripts"}}
+	{{~> @partial-block}}
+	<script src="enemy_stage_search.js" type="module"></script>
+{{/inline}}
+
+{{#*inline "styles-inline"}}
+	<style>
+	body { padding: 12px; font-size: 16px; }
+	#page { max-width: 900px; margin: 0 auto; }
+	h2 { margin-bottom: 12px; }
+	.row { margin: 10px 0; display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+	select {
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		padding: 4px 8px;
+		font-size: 1em;
+	}
+	:root.dark select { background: #282a36; color: #f8f8f2; border-color: #555; }
+	#enemy-slots { display: flex; flex-wrap: wrap; gap: 12px; margin: 10px 0; }
+	.enemy-slot {
+		border: 1px solid #aaa;
+		border-radius: 6px;
+		padding: 8px;
+		min-width: 200px;
+		position: relative;
+	}
+	:root.dark .enemy-slot { border-color: #555; }
+	.slot-label { font-size: 0.85em; color: #888; margin-bottom: 6px; }
+	:root.dark .slot-label { color: #aaa; }
+	.enemy-input {
+		width: 162px;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		padding: 4px 8px;
+		font-size: 1em;
+	}
+	:root.dark .enemy-input { background: #282a36; color: #f8f8f2; border-color: #555; }
+	.enemy-dropdown {
+		position: absolute;
+		z-index: 10;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		background: white;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		width: 230px;
+		max-height: 230px;
+		overflow-y: auto;
+		box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+	}
+	:root.dark .enemy-dropdown { background: #282a36; border-color: #555; }
+	.enemy-dropdown li {
+		padding: 5px 8px;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 0.95em;
+	}
+	.enemy-dropdown li:hover { background: lightcyan; }
+	:root.dark .enemy-dropdown li:hover { background: steelblue; }
+	.enemy-dropdown img { width: 36px; height: 36px; object-fit: contain; }
+	.slot-selected { display: flex; align-items: center; gap: 8px; }
+	.slot-selected img { width: 44px; height: 44px; object-fit: contain; }
+	.deselect-btn {
+		background: none;
+		border: 1px solid #d00;
+		color: #d00;
+		border-radius: 4px;
+		cursor: pointer;
+		padding: 2px 6px;
+		font-size: 0.9em;
+	}
+	.remove-btn {
+		display: block;
+		margin-top: 6px;
+		font-size: 0.8em;
+		padding: 2px 8px;
+		cursor: pointer;
+		border: 1px solid #aaa;
+		border-radius: 4px;
+		background: none;
+		color: inherit;
+	}
+	.remove-btn:hover { background: #fee; }
+	:root.dark .remove-btn:hover { background: #422; }
+	#status { margin: 8px 0; font-size: 0.95em; color: #555; }
+	:root.dark #status { color: #aaa; }
+	#results table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+	#results td { border: 1px solid #575757; padding: 6px 8px; vertical-align: middle; }
+	#results thead td { background: #9d9a834d; font-weight: bold; }
+	:root.dark #results thead td { background: #7171714d; }
+	.matched-enemy { display: inline-flex; align-items: center; gap: 4px; margin: 2px 4px; vertical-align: middle; }
+	.matched-enemy img { width: 32px; height: 32px; object-fit: contain; }
+	</style>
+{{/inline}}
+
+{{#*inline "content"}}
+<div id="page">
+	<h2>敵人關卡查詢</h2>
+	<div class="row">
+		<label for="chapter">章節：</label>
+		<select id="chapter">
+			<option value="3009">世界篇 第一章</option>
+			<option value="3009">世界篇 第二章</option>
+			<option value="3009">世界篇 第三章</option>
+			<option value="3003">未來篇 第一章</option>
+			<option value="3004">未來篇 第二章</option>
+			<option value="3005">未來篇 第三章</option>
+			<option value="3006">宇宙篇 第一章</option>
+			<option value="3007">宇宙篇 第二章</option>
+			<option value="3008">宇宙篇 第三章</option>
+			<option value="legend">傳奇關卡</option>
+		</select>
+	</div>
+	<div class="row">
+		<label>選擇敵人（2–4個）：</label>
+		<button id="add-slot-btn" class="w3-button w3-light-grey w3-round" type="button" disabled>+ 新增敵人</button>
+	</div>
+	<div id="enemy-slots"></div>
+	<div class="row">
+		<button id="do-search-btn" class="w3-button w3-teal w3-round" type="button" disabled>搜尋</button>
+	</div>
+	<div id="status">載入中…</div>
+	<div id="results" hidden>
+		<table>
+			<thead id="results-head">
+				<tr>
+					<td id="col-map" hidden>地圖</td>
+					<td>關卡</td>
+					<td>包含的指定敵人</td>
+					<td>消費統率力</td>
+				</tr>
+			</thead>
+			<tbody id="results-body"></tbody>
+		</table>
+	</div>
+</div>
+{{/inline}}
+
+{{/common.html}}

--- a/template/html/enemy_stage_search.html
+++ b/template/html/enemy_stage_search.html
@@ -72,6 +72,7 @@
 	:root.dark .enemy-dropdown li:hover { background: steelblue; }
 	.enemy-dropdown img { width: 36px; height: 36px; object-fit: contain; }
 	.slot-selected { display: flex; align-items: center; gap: 8px; }
+	.slot-selected[hidden] { display: none; }
 	.slot-selected img { width: 44px; height: 44px; object-fit: contain; }
 	.deselect-btn {
 		background: none;
@@ -82,20 +83,7 @@
 		padding: 2px 6px;
 		font-size: 0.9em;
 	}
-	.remove-btn {
-		display: block;
-		margin-top: 6px;
-		font-size: 0.8em;
-		padding: 2px 8px;
-		cursor: pointer;
-		border: 1px solid #aaa;
-		border-radius: 4px;
-		background: none;
-		color: inherit;
-	}
-	.remove-btn:hover { background: #fee; }
-	:root.dark .remove-btn:hover { background: #422; }
-	#status { margin: 8px 0; font-size: 0.95em; color: #555; }
+#status { margin: 8px 0; font-size: 0.95em; color: #555; }
 	:root.dark #status { color: #aaa; }
 	#results table { width: 100%; border-collapse: collapse; margin-top: 12px; }
 	#results td { border: 1px solid #575757; padding: 6px 8px; vertical-align: middle; }
@@ -112,9 +100,9 @@
 	<div class="row">
 		<label for="chapter">章節：</label>
 		<select id="chapter">
-			<option value="3009">世界篇 第一章</option>
-			<option value="3009">世界篇 第二章</option>
-			<option value="3009">世界篇 第三章</option>
+			<option value="3009" data-star="0">世界篇 第一章</option>
+			<option value="3009" data-star="1">世界篇 第二章</option>
+			<option value="3009" data-star="2">世界篇 第三章</option>
 			<option value="3003">未來篇 第一章</option>
 			<option value="3004">未來篇 第二章</option>
 			<option value="3005">未來篇 第三章</option>
@@ -125,8 +113,7 @@
 		</select>
 	</div>
 	<div class="row">
-		<label>選擇敵人（2–4個）：</label>
-		<button id="add-slot-btn" class="w3-button w3-light-grey w3-round" type="button" disabled>+ 新增敵人</button>
+		<label>選擇敵人：</label>
 	</div>
 	<div id="enemy-slots"></div>
 	<div class="row">

--- a/template/js/enemy_stage_search.js
+++ b/template/js/enemy_stage_search.js
@@ -1,0 +1,241 @@
+import * as Stage from './stage.mjs';
+import {loadAllEnemies} from './unit.mjs';
+
+const chapterSel = document.getElementById('chapter');
+const slotsDiv = document.getElementById('enemy-slots');
+const addSlotBtn = document.getElementById('add-slot-btn');
+const searchBtn = document.getElementById('do-search-btn');
+const resultsDiv = document.getElementById('results');
+const resultsBody = document.getElementById('results-body');
+const colMap = document.getElementById('col-map');
+const statusEl = document.getElementById('status');
+const QQ = '？？？';
+
+let allEnemies = [];
+
+// ── Enemy slot UI ─────────────────────────────────────────────────────────────
+
+function makeSlot(index) {
+	const slot = document.createElement('div');
+	slot.className = 'enemy-slot';
+
+	const label = slot.appendChild(document.createElement('div'));
+	label.className = 'slot-label';
+	label.textContent = `敵人 ${index + 1}`;
+
+	const searchBox = slot.appendChild(document.createElement('div'));
+
+	const input = searchBox.appendChild(document.createElement('input'));
+	input.type = 'text';
+	input.className = 'enemy-input';
+	input.placeholder = '搜尋敵人名稱';
+	input.autocomplete = 'off';
+
+	const dropdown = slot.appendChild(document.createElement('ul'));
+	dropdown.className = 'enemy-dropdown';
+	dropdown.hidden = true;
+
+	const picked = slot.appendChild(document.createElement('div'));
+	picked.className = 'slot-selected';
+	picked.hidden = true;
+	picked.dataset.id = '';
+
+	const pickedImg = picked.appendChild(new Image(44, 44));
+	pickedImg.style.cssText = 'width:44px;height:44px;object-fit:contain';
+	const pickedName = picked.appendChild(document.createElement('span'));
+	const clearBtn = picked.appendChild(document.createElement('button'));
+	clearBtn.className = 'deselect-btn';
+	clearBtn.type = 'button';
+	clearBtn.textContent = '×';
+
+	function pick(e) {
+		picked.dataset.id = e.id;
+		pickedImg.src = e.icon;
+		pickedImg.hidden = false;
+		pickedName.textContent = e.name || e.jp_name || QQ;
+		searchBox.hidden = true;
+		picked.hidden = false;
+		dropdown.hidden = true;
+	}
+
+	function clear() {
+		picked.dataset.id = '';
+		input.value = '';
+		searchBox.hidden = false;
+		picked.hidden = true;
+	}
+
+	input.addEventListener('input', () => {
+		const q = input.value.trim().toLowerCase();
+		dropdown.innerHTML = '';
+		if (!q) { dropdown.hidden = true; return; }
+		const hits = allEnemies.filter(e =>
+			(e.name || '').toLowerCase().includes(q) ||
+			(e.jp_name || '').toLowerCase().includes(q) ||
+			(e.fandom || '').toLowerCase().includes(q)
+		).slice(0, 12);
+		if (!hits.length) { dropdown.hidden = true; return; }
+		for (const e of hits) {
+			const li = dropdown.appendChild(document.createElement('li'));
+			const img = li.appendChild(new Image(36, 36));
+			img.src = e.icon;
+			img.style.cssText = 'width:36px;height:36px;object-fit:contain';
+			img.onerror = () => { img.hidden = true; };
+			li.appendChild(document.createTextNode(e.name || e.jp_name || QQ));
+			li.addEventListener('mousedown', ev => { ev.preventDefault(); pick(e); });
+		}
+		dropdown.hidden = false;
+	});
+
+	input.addEventListener('blur', () => setTimeout(() => { dropdown.hidden = true; }, 150));
+	clearBtn.addEventListener('click', clear);
+
+	if (index >= 2) {
+		const rmBtn = slot.appendChild(document.createElement('button'));
+		rmBtn.type = 'button';
+		rmBtn.className = 'remove-btn';
+		rmBtn.textContent = '移除';
+		rmBtn.addEventListener('click', () => {
+			slot.remove();
+			refreshLabels();
+			addSlotBtn.disabled = slotsDiv.children.length >= 4;
+		});
+	}
+
+	slot.getEnemyId = () => {
+		const v = picked.dataset.id;
+		return v !== '' ? parseInt(v) : null;
+	};
+
+	return slot;
+}
+
+function refreshLabels() {
+	Array.from(slotsDiv.children).forEach((s, i) => {
+		s.querySelector('.slot-label').textContent = `敵人 ${i + 1}`;
+	});
+}
+
+addSlotBtn.addEventListener('click', () => {
+	if (slotsDiv.children.length < 4) {
+		slotsDiv.appendChild(makeSlot(slotsDiv.children.length));
+		addSlotBtn.disabled = slotsDiv.children.length >= 4;
+	}
+});
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+function parseStageEnemyIds(enemyLines) {
+	if (!enemyLines) return new Set();
+	const ids = new Set();
+	for (const line of enemyLines.split('|')) {
+		const raw = line.split(',')[0];
+		if (raw) {
+			const id = parseInt(raw, 36);
+			if (!isNaN(id)) ids.add(id);
+		}
+	}
+	return ids;
+}
+
+searchBtn.addEventListener('click', async () => {
+	const slots = Array.from(slotsDiv.children);
+	const ids = [...new Set(slots.map(s => s.getEnemyId()).filter(id => id !== null))];
+
+	if (ids.length < 2) {
+		statusEl.textContent = '請至少選擇 2 個不同的敵人';
+		return;
+	}
+
+	const chapterVal = chapterSel.value;
+	const isLegend = chapterVal === 'legend';
+
+	searchBtn.disabled = true;
+	statusEl.textContent = '搜尋中…';
+	resultsDiv.hidden = true;
+	resultsBody.innerHTML = '';
+	colMap.hidden = !isLegend;
+
+	const hits = [];
+	const query = isLegend
+		? IDBKeyRange.bound(0, 49000, false, true)
+		: IDBKeyRange.bound(parseInt(chapterVal) * 1000, parseInt(chapterVal) * 1000 + 1000, false, true);
+
+	for await (const stage of Stage.forEachStage(query)) {
+		const stageIds = parseStageEnemyIds(stage.enemyLines);
+		const matched = ids.filter(id => stageIds.has(id));
+		if (matched.length) hits.push({stage, matched});
+	}
+
+	hits.sort((a, b) => b.matched.length - a.matched.length || a.stage.id - b.stage.id);
+
+	searchBtn.disabled = false;
+
+	if (!hits.length) { statusEl.textContent = '找不到符合的關卡'; return; }
+	statusEl.textContent = `找到 ${hits.length} 個關卡`;
+
+	const byId = Object.fromEntries(allEnemies.map(e => [e.id, e]));
+	const mapNameCache = {};
+
+	async function getMapName(mapId) {
+		if (mapId in mapNameCache) return mapNameCache[mapId];
+		const map = await Stage.getMap(mapId);
+		return (mapNameCache[mapId] = map ? (map.name || map.nameJp || QQ) : QQ);
+	}
+
+	for (const {stage, matched} of hits) {
+		const tr = resultsBody.appendChild(document.createElement('tr'));
+
+		const mc = Math.floor(stage.id / 1000000);
+		const sm = Math.floor((stage.id % 1000000) / 1000);
+		const st = stage.id % 1000;
+		const mapId = mc * 1000 + sm;
+
+		if (isLegend) {
+			const tdMap = tr.appendChild(document.createElement('td'));
+			getMapName(mapId).then(n => { tdMap.textContent = `${sm + 1}. ${n}`; });
+		}
+
+		const tdName = tr.appendChild(document.createElement('td'));
+		const a = tdName.appendChild(document.createElement('a'));
+		a.href = `/stage.html?s=${mc}-${sm}-${st}`;
+		a.textContent = stage.name || stage.nameJp || QQ;
+
+		const tdEnemies = tr.appendChild(document.createElement('td'));
+		for (const id of matched) {
+			const e = byId[id];
+			const span = tdEnemies.appendChild(document.createElement('span'));
+			span.className = 'matched-enemy';
+			if (e) {
+				const img = span.appendChild(new Image(32, 32));
+				img.src = e.icon;
+				img.style.cssText = 'width:32px;height:32px;object-fit:contain';
+				img.onerror = () => { img.hidden = true; };
+				span.appendChild(document.createTextNode(e.name || e.jp_name || QQ));
+			} else {
+				span.textContent = `#${id}`;
+			}
+		}
+
+		const tdEnergy = tr.appendChild(document.createElement('td'));
+		tdEnergy.textContent = stage.energy ?? '-';
+	}
+
+	resultsDiv.hidden = false;
+});
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+
+(async () => {
+	try {
+		allEnemies = await loadAllEnemies();
+		statusEl.textContent = '';
+	} catch (err) {
+		statusEl.textContent = `載入敵人資料失敗：${err.message}`;
+	} finally {
+		slotsDiv.appendChild(makeSlot(0));
+		slotsDiv.appendChild(makeSlot(1));
+		addSlotBtn.disabled = false;
+		searchBtn.disabled = false;
+	}
+})();

--- a/template/js/enemy_stage_search.js
+++ b/template/js/enemy_stage_search.js
@@ -70,25 +70,44 @@ function makeSlot(index) {
 		const q = input.value.trim().toLowerCase();
 		dropdown.innerHTML = '';
 		if (!q) { dropdown.hidden = true; return; }
+		const usedIds = new Set(
+			Array.from(slotsDiv.children).map(s => s.getEnemyId()).filter(id => id !== null)
+		);
 		const hits = allEnemies.filter(e =>
-			(e.name || '').toLowerCase().includes(q) ||
-			(e.jp_name || '').toLowerCase().includes(q) ||
-			(e.fandom || '').toLowerCase().includes(q)
+			!usedIds.has(e.id) && (
+				(e.name || '').toLowerCase().includes(q) ||
+				(e.jp_name || '').toLowerCase().includes(q) ||
+				(e.fandom || '').toLowerCase().includes(q)
+			)
 		).slice(0, 12);
 		if (!hits.length) { dropdown.hidden = true; return; }
 		for (const e of hits) {
 			const li = dropdown.appendChild(document.createElement('li'));
+			li.tabIndex = -1;
 			const img = li.appendChild(new Image(36, 36));
 			img.src = e.icon;
 			img.style.cssText = 'width:36px;height:36px;object-fit:contain';
 			img.onerror = () => { img.hidden = true; };
 			li.appendChild(document.createTextNode(e.name || e.jp_name || QQ));
 			li.addEventListener('mousedown', ev => { ev.preventDefault(); pick(e); });
+			li.addEventListener('keydown', ev => {
+				if (ev.key === 'Enter') { ev.preventDefault(); pick(e); }
+				else if (ev.key === 'ArrowDown') { ev.preventDefault(); (li.nextElementSibling || dropdown.firstElementChild)?.focus(); }
+				else if (ev.key === 'ArrowUp') { ev.preventDefault(); li.previousElementSibling ? li.previousElementSibling.focus() : input.focus(); }
+				else if (ev.key === 'Escape') { dropdown.hidden = true; input.focus(); }
+			});
 		}
 		dropdown.hidden = false;
 	});
 
-	input.addEventListener('blur', () => setTimeout(() => { dropdown.hidden = true; }, 150));
+	input.addEventListener('keydown', ev => {
+		if (ev.key === 'ArrowDown' && !dropdown.hidden) { ev.preventDefault(); dropdown.firstElementChild?.focus(); }
+		else if (ev.key === 'Escape') { dropdown.hidden = true; }
+	});
+
+	slot.addEventListener('focusout', ev => {
+		if (!slot.contains(ev.relatedTarget)) dropdown.hidden = true;
+	});
 	clearBtn.addEventListener('click', clear);
 
 	slot.getEnemyId = () => {

--- a/template/js/enemy_stage_search.js
+++ b/template/js/enemy_stage_search.js
@@ -3,7 +3,6 @@ import {loadAllEnemies} from './unit.mjs';
 
 const chapterSel = document.getElementById('chapter');
 const slotsDiv = document.getElementById('enemy-slots');
-const addSlotBtn = document.getElementById('add-slot-btn');
 const searchBtn = document.getElementById('do-search-btn');
 const resultsDiv = document.getElementById('results');
 const resultsBody = document.getElementById('results-body');
@@ -60,6 +59,8 @@ function makeSlot(index) {
 
 	function clear() {
 		picked.dataset.id = '';
+		pickedImg.src = '';
+		pickedImg.hidden = true;
 		input.value = '';
 		searchBox.hidden = false;
 		picked.hidden = true;
@@ -90,18 +91,6 @@ function makeSlot(index) {
 	input.addEventListener('blur', () => setTimeout(() => { dropdown.hidden = true; }, 150));
 	clearBtn.addEventListener('click', clear);
 
-	if (index >= 2) {
-		const rmBtn = slot.appendChild(document.createElement('button'));
-		rmBtn.type = 'button';
-		rmBtn.className = 'remove-btn';
-		rmBtn.textContent = '移除';
-		rmBtn.addEventListener('click', () => {
-			slot.remove();
-			refreshLabels();
-			addSlotBtn.disabled = slotsDiv.children.length >= 4;
-		});
-	}
-
 	slot.getEnemyId = () => {
 		const v = picked.dataset.id;
 		return v !== '' ? parseInt(v) : null;
@@ -109,19 +98,6 @@ function makeSlot(index) {
 
 	return slot;
 }
-
-function refreshLabels() {
-	Array.from(slotsDiv.children).forEach((s, i) => {
-		s.querySelector('.slot-label').textContent = `敵人 ${i + 1}`;
-	});
-}
-
-addSlotBtn.addEventListener('click', () => {
-	if (slotsDiv.children.length < 4) {
-		slotsDiv.appendChild(makeSlot(slotsDiv.children.length));
-		addSlotBtn.disabled = slotsDiv.children.length >= 4;
-	}
-});
 
 // ── Search ────────────────────────────────────────────────────────────────────
 
@@ -142,13 +118,15 @@ searchBtn.addEventListener('click', async () => {
 	const slots = Array.from(slotsDiv.children);
 	const ids = [...new Set(slots.map(s => s.getEnemyId()).filter(id => id !== null))];
 
-	if (ids.length < 2) {
-		statusEl.textContent = '請至少選擇 2 個不同的敵人';
+	if (!ids.length) {
+		statusEl.textContent = '請至少選擇 1 個敵人';
 		return;
 	}
 
 	const chapterVal = chapterSel.value;
 	const isLegend = chapterVal === 'legend';
+	const starAttr = chapterSel.selectedOptions[0].dataset.star;
+	const starIndex = starAttr !== undefined ? parseInt(starAttr) : -1;
 
 	searchBtn.disabled = true;
 	statusEl.textContent = '搜尋中…';
@@ -218,7 +196,9 @@ searchBtn.addEventListener('click', async () => {
 		}
 
 		const tdEnergy = tr.appendChild(document.createElement('td'));
-		tdEnergy.textContent = stage.energy ?? '-';
+		const energy = stage.energy ?? null;
+		tdEnergy.textContent = energy === null ? '-' :
+			starIndex >= 0 ? energy + starIndex * 10 : energy;
 	}
 
 	resultsDiv.hidden = false;
@@ -233,9 +213,7 @@ searchBtn.addEventListener('click', async () => {
 	} catch (err) {
 		statusEl.textContent = `載入敵人資料失敗：${err.message}`;
 	} finally {
-		slotsDiv.appendChild(makeSlot(0));
-		slotsDiv.appendChild(makeSlot(1));
-		addSlotBtn.disabled = false;
+		for (let i = 0; i < 4; i++) slotsDiv.appendChild(makeSlot(i));
 		searchBtn.disabled = false;
 	}
 })();

--- a/template/js/enemy_stage_search.js
+++ b/template/js/enemy_stage_search.js
@@ -7,10 +7,109 @@ const searchBtn = document.getElementById('do-search-btn');
 const resultsDiv = document.getElementById('results');
 const resultsBody = document.getElementById('results-body');
 const colMap = document.getElementById('col-map');
+const colEnergy = document.getElementById('col-energy');
 const statusEl = document.getElementById('status');
 const QQ = '？？？';
 
 let allEnemies = [];
+
+// ── Sort state ────────────────────────────────────────────────────────────────
+
+let lastHits = [];
+let lastIsLegend = false;
+let lastStarIndex = -1;
+let lastById = {};
+const mapNameCache = {};
+let sortCol = null; // null | 'map' | 'energy'
+let sortDir = 'asc';
+
+async function getMapName(mapId) {
+	if (mapId in mapNameCache) return mapNameCache[mapId];
+	const map = await Stage.getMap(mapId);
+	return (mapNameCache[mapId] = map ? (map.name || map.nameJp || QQ) : QQ);
+}
+
+function computeEnergy(stage) {
+	const e = stage.energy ?? null;
+	return e === null ? null : lastStarIndex >= 0 ? e + lastStarIndex * 10 : e;
+}
+
+function getSortedHits() {
+	const arr = [...lastHits];
+	if (sortCol === 'energy') {
+		arr.sort((a, b) => {
+			const ea = computeEnergy(a.stage) ?? 0;
+			const eb = computeEnergy(b.stage) ?? 0;
+			return sortDir === 'asc' ? ea - eb || a.stage.id - b.stage.id
+			                         : eb - ea || a.stage.id - b.stage.id;
+		});
+	}
+	return arr;
+}
+
+function updateSortHeaders() {
+	colEnergy.textContent = '消費統率力 ' + (sortCol === 'energy' ? (sortDir === 'asc' ? '▲' : '▼') : '⇅');
+}
+
+function renderTable() {
+	updateSortHeaders();
+	resultsBody.innerHTML = '';
+	for (const {stage, matched} of getSortedHits()) {
+		const tr = resultsBody.appendChild(document.createElement('tr'));
+
+		const mc = Math.floor(stage.id / 1000000);
+		const sm = Math.floor((stage.id % 1000000) / 1000);
+		const st = stage.id % 1000;
+		const mapId = mc * 1000 + sm;
+
+		if (lastIsLegend) {
+			const tdMap = tr.appendChild(document.createElement('td'));
+			getMapName(mapId).then(n => { tdMap.textContent = `${sm + 1}. ${n}`; });
+		}
+
+		const tdName = tr.appendChild(document.createElement('td'));
+		const a = tdName.appendChild(document.createElement('a'));
+		a.href = `/stage.html?s=${mc}-${sm}-${st}`;
+		a.textContent = stage.name || stage.nameJp || QQ;
+
+		const tdEnemies = tr.appendChild(document.createElement('td'));
+		for (const id of matched) {
+			const e = lastById[id];
+			const span = tdEnemies.appendChild(document.createElement('span'));
+			span.className = 'matched-enemy';
+			if (e) {
+				const img = span.appendChild(new Image(32, 32));
+				img.src = e.icon;
+				img.style.cssText = 'width:32px;height:32px;object-fit:contain';
+				img.onerror = () => { img.hidden = true; };
+				span.appendChild(document.createTextNode(e.name || e.jp_name || QQ));
+			} else {
+				span.textContent = `#${id}`;
+			}
+		}
+
+		const tdEnergy = tr.appendChild(document.createElement('td'));
+		const energy = computeEnergy(stage);
+		tdEnergy.textContent = energy === null ? '-' : energy;
+	}
+}
+
+function onSortClick(col) {
+	if (!lastHits.length) return;
+	if (sortCol !== col) {
+		sortCol = col;
+		sortDir = 'asc';
+	} else if (col === 'energy' && sortDir === 'asc') {
+		sortDir = 'desc';
+	} else {
+		sortCol = null;
+	}
+	renderTable();
+}
+
+colEnergy.classList.add('sortable');
+colEnergy.addEventListener('click', () => onSortClick('energy'));
+updateSortHeaders();
 
 // ── Enemy slot UI ─────────────────────────────────────────────────────────────
 
@@ -171,54 +270,13 @@ searchBtn.addEventListener('click', async () => {
 	if (!hits.length) { statusEl.textContent = '找不到符合的關卡'; return; }
 	statusEl.textContent = `找到 ${hits.length} 個關卡`;
 
-	const byId = Object.fromEntries(allEnemies.map(e => [e.id, e]));
-	const mapNameCache = {};
-
-	async function getMapName(mapId) {
-		if (mapId in mapNameCache) return mapNameCache[mapId];
-		const map = await Stage.getMap(mapId);
-		return (mapNameCache[mapId] = map ? (map.name || map.nameJp || QQ) : QQ);
-	}
-
-	for (const {stage, matched} of hits) {
-		const tr = resultsBody.appendChild(document.createElement('tr'));
-
-		const mc = Math.floor(stage.id / 1000000);
-		const sm = Math.floor((stage.id % 1000000) / 1000);
-		const st = stage.id % 1000;
-		const mapId = mc * 1000 + sm;
-
-		if (isLegend) {
-			const tdMap = tr.appendChild(document.createElement('td'));
-			getMapName(mapId).then(n => { tdMap.textContent = `${sm + 1}. ${n}`; });
-		}
-
-		const tdName = tr.appendChild(document.createElement('td'));
-		const a = tdName.appendChild(document.createElement('a'));
-		a.href = `/stage.html?s=${mc}-${sm}-${st}`;
-		a.textContent = stage.name || stage.nameJp || QQ;
-
-		const tdEnemies = tr.appendChild(document.createElement('td'));
-		for (const id of matched) {
-			const e = byId[id];
-			const span = tdEnemies.appendChild(document.createElement('span'));
-			span.className = 'matched-enemy';
-			if (e) {
-				const img = span.appendChild(new Image(32, 32));
-				img.src = e.icon;
-				img.style.cssText = 'width:32px;height:32px;object-fit:contain';
-				img.onerror = () => { img.hidden = true; };
-				span.appendChild(document.createTextNode(e.name || e.jp_name || QQ));
-			} else {
-				span.textContent = `#${id}`;
-			}
-		}
-
-		const tdEnergy = tr.appendChild(document.createElement('td'));
-		const energy = stage.energy ?? null;
-		tdEnergy.textContent = energy === null ? '-' :
-			starIndex >= 0 ? energy + starIndex * 10 : energy;
-	}
+	lastHits = hits;
+	lastIsLegend = isLegend;
+	lastStarIndex = starIndex;
+	lastById = Object.fromEntries(allEnemies.map(e => [e.id, e]));
+	sortCol = null;
+	sortDir = 'asc';
+	renderTable();
 
 	resultsDiv.hidden = false;
 });

--- a/template/layouts/base.html.hbs
+++ b/template/layouts/base.html.hbs
@@ -144,6 +144,7 @@
 		<a href="/gachas.html"{{#if (op nav_bar_active "===" "gacha")}} class="active"{{/if}}>轉蛋</a>
 		<a href="/stage.html"{{#if (op nav_bar_active "===" "stage")}} class="active"{{/if}}>關卡</a>
 		<a href="/schedule.html"{{#if (op nav_bar_active "===" "schedule")}} class="active"{{/if}}>日程</a>
+		<a href="/enemy_stage_search.html"{{#if (op nav_bar_active "===" "enemy_stage_search")}} class="active"{{/if}}>月任務</a>
 		{{#> nav-bar-content-settings}}
 		<a title="設定" href="/settings.html" style="float:right;">
 			<svg viewBox="0 0 24 24">


### PR DESCRIPTION
New page /enemy_stage_search.html — 依敵人查詢關卡（月任務）
功能

- 選擇 1–4 個敵人（含自動完成搜尋，支援繁中／日文／英文名稱）
- 章節選單：世界篇 1/2/3、未來篇 1/2/3、宇宙篇 1/2/3、傳奇關卡（49 個大關）
- 結果依符合敵人數排序，同數量者依關卡預設順序
- 消費統率力欄位可點擊切換升冪／降冪／預設排序
- 傳奇關卡結果顯示地圖編號與名稱
- 世界篇統率力依章節正確換算（+10／+20）
- 敵人選單支援鍵盤操作（↓ 進入、↑↓ 移動、Enter 選擇、Esc 關閉）
- 導覽列新增「月任務」連結

This page was built with the help of Claude (Anthropic AI).